### PR TITLE
fwrite() php 8.0 - Fix null being passed where string is expected

### DIFF
--- a/src/main/php/appenders/LoggerAppenderConsole.php
+++ b/src/main/php/appenders/LoggerAppenderConsole.php
@@ -55,7 +55,7 @@
 	public function activateOptions() {
 		$this->fp = fopen($this->target, 'w');
 		if(is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->getHeader());
+			fwrite($this->fp, $this->layout->getHeader() ?? '' );
 		}
 		$this->closed = (bool)is_resource($this->fp) === false;
 	}
@@ -64,7 +64,7 @@
 	public function close() {
 		if($this->closed != true) {
 			if (is_resource($this->fp) && $this->layout !== null) {
-				fwrite($this->fp, $this->layout->getFooter());
+				fwrite($this->fp, $this->layout->getFooter() ?? '' );
 				fclose($this->fp);
 			}
 			$this->closed = true;
@@ -73,7 +73,7 @@
 
 	public function append(LoggerLoggingEvent $event) {
 		if (is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->format($event));
+			fwrite($this->fp, $this->layout->format($event) ?? '' );
 		}
 	}
 	


### PR DESCRIPTION
PHP 8 fwrite() does not accept null as a parameter, only string.