### PR TITLE
PHP 8.0+ Fixes

### DIFF
--- a/src/main/php/appenders/LoggerAppenderConsole.php
+++ b/src/main/php/appenders/LoggerAppenderConsole.php
@@ -55,7 +55,7 @@
 	public function activateOptions() {
 		$this->fp = fopen($this->target, 'w');
 		if(is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->getHeader());
+			fwrite($this->fp, $this->layout->getHeader() ?? '' );
 		}
 		$this->closed = (bool)is_resource($this->fp) === false;
 	}
@@ -64,7 +64,7 @@
 	public function close() {
 		if($this->closed != true) {
 			if (is_resource($this->fp) && $this->layout !== null) {
-				fwrite($this->fp, $this->layout->getFooter());
+				fwrite($this->fp, $this->layout->getFooter() ?? '' );
 				fclose($this->fp);
 			}
 			$this->closed = true;
@@ -73,7 +73,7 @@
 
 	public function append(LoggerLoggingEvent $event) {
 		if (is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->format($event));
+			fwrite($this->fp, $this->layout->format($event) ?? '' );
 		}
 	}
 	

--- a/src/main/php/appenders/LoggerAppenderConsole.php
+++ b/src/main/php/appenders/LoggerAppenderConsole.php
@@ -55,7 +55,7 @@
 	public function activateOptions() {
 		$this->fp = fopen($this->target, 'w');
 		if(is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->getHeader() ?? '' );
+			fwrite($this->fp, $this->layout->getHeader() ?? '');
 		}
 		$this->closed = (bool)is_resource($this->fp) === false;
 	}
@@ -64,7 +64,7 @@
 	public function close() {
 		if($this->closed != true) {
 			if (is_resource($this->fp) && $this->layout !== null) {
-				fwrite($this->fp, $this->layout->getFooter() ?? '' );
+				fwrite($this->fp, $this->layout->getFooter() ?? '');
 				fclose($this->fp);
 			}
 			$this->closed = true;
@@ -73,7 +73,7 @@
 
 	public function append(LoggerLoggingEvent $event) {
 		if (is_resource($this->fp) && $this->layout !== null) {
-			fwrite($this->fp, $this->layout->format($event) ?? '' );
+			fwrite($this->fp, $this->layout->format($event) ?? '');
 		}
 	}
 	

--- a/src/main/php/appenders/LoggerAppenderSocket.php
+++ b/src/main/php/appenders/LoggerAppenderSocket.php
@@ -79,7 +79,7 @@ class LoggerAppenderSocket extends LoggerAppender {
 			return;
 		}
 	
-		if (false === fwrite($socket, $this->layout->format($event))) {
+		if (false === fwrite($socket, $this->layout->format($event) ?? '' )) {
 			$this->warn("Error writing to socket. Closing appender.");
 			$this->closed = true;
 		}

--- a/src/main/php/pattern/LoggerPatternConverterDate.php
+++ b/src/main/php/pattern/LoggerPatternConverterDate.php
@@ -69,9 +69,9 @@ class LoggerPatternConverterDate extends LoggerPatternConverter {
 	
 	public function convert(LoggerLoggingEvent $event) {
 		if ($this->useLocalDate) {
-			return $this->date($this->format, $event->getTimeStamp());
+			return $this->date($this->format, (int) $event->getTimeStamp());
 		}
-		return date($this->format, $event->getTimeStamp());
+		return date($this->format, (int) $event->getTimeStamp());
 	}
 	
 	/**


### PR DESCRIPTION
`fwrite()` does not accept null as a parameter, only string.
float casting to int automatically is not accepted, require to cast it implicitly.

Projects nds/nds and nds/ndcaptchams are using this package out of my user, `arminanton`'s repo and branch named `jkenn99`, because we needed to push these changes ASAP, and JK is/was on leave until Jan 2023.